### PR TITLE
Work in progress: Record & Tuple integration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7747,8 +7747,8 @@ values are represented by ECMAScript Object values (including [=function objects
 <h4 id="es-dictionary">Dictionary types</h4>
 
 IDL [=dictionary type=] values are represented
-by ECMAScript Object values.  Properties on
-the object (or its prototype chain) correspond to [=dictionary members=].
+by ECMAScript Object or Record values. Properties on the
+object (or its prototype chain) or the record correspond to [=dictionary members=].
 
 <div id="es-to-dictionary" algorithm="convert an ECMAScript value to dictionary">
 
@@ -7756,7 +7756,7 @@ the object (or its prototype chain) correspond to [=dictionary members=].
     to an IDL [=dictionary type=] value by
     running the following algorithm (where |D| is the [=dictionary type=]):
 
-    1.  If <a abstract-op>Type</a>(|esDict|) is not Undefined, Null or Object, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
+    1.  If <a abstract-op>Type</a>(|esDict|) is not Undefined, Null, Object or Record, then [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Let |idlDict| be an empty [=ordered map=], representing a dictionary of type |D|.
     1.  Let |dictionaries| be a list consisting of |D| and all of |D|'s [=inherited dictionaries=],
         in order from least to most derived.
@@ -7769,7 +7769,7 @@ the object (or its prototype chain) correspond to [=dictionary members=].
                      :  Null
                      :: <emu-val>undefined</emu-val>
                      :  anything else
-                     :: [=?=] <a abstract-op>Get</a>(|esDict|, |key|)
+                     :: [=?=] <a abstract-op>Get</a>([=?=] <a abstract-op>ToObject</a>(|esDict|), |key|)
                 </dl>
             1.  If |esMemberValue| is not <emu-val>undefined</emu-val>, then:
                 1.  Let |idlMemberValue| be the result of [=converted to an IDL value|converting=] |esMemberValue| to an IDL value whose type is the type |member| is declared to be of.
@@ -7783,7 +7783,7 @@ the object (or its prototype chain) correspond to [=dictionary members=].
 </div>
 
 Note: The order that [=dictionary members=] are looked
-up on the ECMAScript object are not necessarily the same as the object's property enumeration order.
+up on the ECMAScript object or record are not necessarily the same as the object's or record's property enumeration order.
 
 <div id="dictionary-to-es" algorithm="convert a dictionary to an ECMAScript value">
 

--- a/index.bs
+++ b/index.bs
@@ -7914,16 +7914,17 @@ the ECMAScript <emu-val>null</emu-val> value.
 <h4 id="es-sequence">Sequences — sequence&lt;|T|&gt;</h4>
 
 IDL <a lt="sequence type">sequence&lt;|T|&gt;</a> values are represented by
-ECMAScript Array values.
+ECMAScript Array or Tuple values.
 
 <div id="es-to-sequence" algorithm="convert an ECMAScript value to sequence">
 
     An ECMAScript value |V| is [=converted to an IDL value|converted=]
     to an IDL <a lt="sequence type">sequence&lt;<var ignore>T</var>&gt;</a> value as follows:
 
-    1.  If <a abstract-op>Type</a>(|V|) is not Object,
+    1.  If <a abstract-op>Type</a>(|V|) is not Object or Tuple,
         [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
-    1.  Let |method| be [=?=] <a abstract-op>GetMethod</a>(|V|, {{@@iterator}}).
+    1.  Let |obj| be [=?=] <a abstract-op>ToObject</a>(|V|)
+    1.  Let |method| be [=?=] <a abstract-op>GetMethod</a>(|obj|, {{@@iterator}}).
     1.  If |method| is <emu-val>undefined</emu-val>,
         [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the result of [=creating a sequence from an iterable|creating a sequence=]

--- a/index.bs
+++ b/index.bs
@@ -7760,6 +7760,7 @@ object (or its prototype chain) or the record correspond to [=dictionary members
     1.  Let |idlDict| be an empty [=ordered map=], representing a dictionary of type |D|.
     1.  Let |dictionaries| be a list consisting of |D| and all of |D|'s [=inherited dictionaries=],
         in order from least to most derived.
+    1.  Let |obj| be [=?=] <a abstract-op>ToObject</a>(|esDict|) if <a abstract-op>Type</a>(|esDict|) is not Undefined or Null
     1.  For each dictionary |dictionary| in |dictionaries|, in order:
         1.  For each dictionary member |member| declared on |dictionary|, in lexicographical order:
             1.  Let |key| be the [=identifier=] of |member|.
@@ -7769,9 +7770,7 @@ object (or its prototype chain) or the record correspond to [=dictionary members
                      :  Null
                      :: <emu-val>undefined</emu-val>
                      :  anything else
-                     :: 
-                        1. Let |obj| be [=?=] <a abstract-op>ToObject</a>(|esDict|)
-                        1. [=?=] <a abstract-op>Get</a>(|obj|, |key|)
+                     :: [=?=] <a abstract-op>Get</a>(|obj|, |key|)
                 </dl>
             1.  If |esMemberValue| is not <emu-val>undefined</emu-val>, then:
                 1.  Let |idlMemberValue| be the result of [=converted to an IDL value|converting=] |esMemberValue| to an IDL value whose type is the type |member| is declared to be of.

--- a/index.bs
+++ b/index.bs
@@ -7769,7 +7769,9 @@ object (or its prototype chain) or the record correspond to [=dictionary members
                      :  Null
                      :: <emu-val>undefined</emu-val>
                      :  anything else
-                     :: [=?=] <a abstract-op>Get</a>([=?=] <a abstract-op>ToObject</a>(|esDict|), |key|)
+                     :: 
+                        1. Let |obj| be [=?=] <a abstract-op>ToObject</a>(|esDict|)
+                        1. [=?=] <a abstract-op>Get</a>(|obj|, |key|)
                 </dl>
             1.  If |esMemberValue| is not <emu-val>undefined</emu-val>, then:
                 1.  Let |idlMemberValue| be the result of [=converted to an IDL value|converting=] |esMemberValue| to an IDL value whose type is the type |member| is declared to be of.

--- a/index.bs
+++ b/index.bs
@@ -7924,8 +7924,7 @@ ECMAScript Array or Tuple values.
 
     1.  If <a abstract-op>Type</a>(|V|) is not Object or Tuple,
         [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
-    1.  Let |obj| be [=?=] <a abstract-op>ToObject</a>(|V|)
-    1.  Let |method| be [=?=] <a abstract-op>GetMethod</a>(|obj|, {{@@iterator}}).
+    1.  Let |method| be [=?=] <a abstract-op>GetMethod</a>(|V|, {{@@iterator}}).
     1.  If |method| is <emu-val>undefined</emu-val>,
         [=ECMAScript/throw=] a {{ECMAScript/TypeError}}.
     1.  Return the result of [=creating a sequence from an iterable|creating a sequence=]


### PR DESCRIPTION
<!--
Thank you for contributing to the Web IDL Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …
   * Deno: …
   * Node.js: …
   * webidl2.js: …
   * widlparser: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)

---

This candidate change aims to integrate the now Stage 2 [Record & Tuple](https://github.com/tc39/proposal-record-tuple) TC39 proposal in WebIDL.

Our current & minimal goal in integrating in WebIDL is to first make APIs tolerate Records in-place of option bags and Tuples in-place of enumerables. This means we are only defining an interaction with ECMAScript for now, no new WebIDL types. This would enable a developer to write the following:

```js
const headers = #{
  'Content-Type': 'text/xml',
};
await fetch('https://example.com/', #{ method: "PUT", headers });
```

If and when Record & Tuple usage in JS is proven and DOM APIs would want to be able to return them, we will consider adding them as WebIDL types.